### PR TITLE
Fixed missing parameters to init and logging hooks and case sensitive import issues

### DIFF
--- a/consumer/main.go
+++ b/consumer/main.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	wpwtypes "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 	"github.com/rifflock/lfshook"
 	log "github.com/sirupsen/logrus"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	wpwtypes "github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // Application flags
@@ -53,7 +53,7 @@ func main() {
 	err = performSetup()
 	errCheck(err, "performSetup()")
 
-	_wpw, err := wpwithin.Initialise("pi-led-consumer", "Worldpay Within Pi LED Demo - Consumer")
+	_wpw, err := wpwithin.Initialise("pi-led-consumer", "Worldpay Within Pi LED Demo - Consumer", "")
 	wpw = _wpw
 
 	errCheck(err, "WorldpayWithin Initialise")
@@ -236,7 +236,7 @@ func initLog() error {
 		log.WarnLevel:  "logs/warn.log",
 		log.PanicLevel: "logs/panic.log",
 		log.FatalLevel: "logs/fatal.log",
-	}))
+	}, new(log.TextFormatter)))
 
 	f, err := os.OpenFile("/dev/null", os.O_WRONLY|os.O_CREATE, 0755)
 

--- a/producer/handler.go
+++ b/producer/handler.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 	"github.com/stianeikeland/go-rpio"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // Handler handles the events coming from Worldpay Within

--- a/producer/main.go
+++ b/producer/main.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 	"github.com/rifflock/lfshook"
 	log "github.com/sirupsen/logrus"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // Application flags
@@ -56,7 +56,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	_wpw, err := wpwithin.Initialise("pi-led-producer", "Worldpay Within Pi LED Demo - Producer")
+	_wpw, err := wpwithin.Initialise("pi-led-producer", "Worldpay Within Pi LED Demo - Producer", "")
 	wpw = _wpw
 
 	errCheck(err, "WorldpayWithin Initialise")
@@ -268,7 +268,7 @@ func initLog() error {
 		log.WarnLevel:  "logs/warn.log",
 		log.PanicLevel: "logs/panic.log",
 		log.FatalLevel: "logs/fatal.log",
-	}))
+	}, new(log.TextFormatter)))
 
 	f, err := os.OpenFile("/dev/null", os.O_WRONLY|os.O_CREATE, 0755)
 


### PR DESCRIPTION
There were inconsistencies across the repo's in terms of import names being in different cases. I think this may have been fixed using vending, but I corrected the core code and cleaned it up. Not sure if this is what is wanted or not, but here is the pull request that cleans it all up. 